### PR TITLE
Small fixes for differentiable Jaxwell

### DIFF
--- a/jaxwell/fdfd.py
+++ b/jaxwell/fdfd.py
@@ -61,7 +61,8 @@ def solve_bwd(params, res, grad):
   x_grad, _ = grad
   x_adj, _ = solve_impl(z, x_grad, adjoint=True, params=params)
   z_grad = tuple(np.real(np.conj(a) * b) for a, b in zip(x_adj, x))
-  return z_grad, x_adj
+  b_grad = tuple(np.conj(a) for a in x_adj)
+  return z_grad, b_grad
 
 
 solve.defvjp(solve_fwd, solve_bwd)

--- a/jaxwell/fdfd.py
+++ b/jaxwell/fdfd.py
@@ -14,14 +14,14 @@ class Params:
   '''Parameters for FDFD solves.
 
   Attributes:
-    ths: `((-x, +x), (-y, +y), (-z, +z))` PML thicknesses.
-    pml_params: `operators.PmlParams` controlling PML parameters.
+    pml_ths: `((-x, +x), (-y, +y), (-z, +z))` PML thicknesses.
+    pml_omega: Effective angular frequency to tune the PML to.
     eps: Error threshold stopping condition.
     max_iters: Iteration number stopping condition.
   '''
   pml_ths: Tuple[Tuple[int, int], Tuple[int, int],
                  Tuple[int, int]] = ((10, 10), (10, 10), (10, 10))
-  pml_params: operators.PmlParams = operators.PmlParams()
+  pml_omega: float = 1.
   eps: float = 1e-6
   max_iters: int = 1000000
 
@@ -94,11 +94,12 @@ def solve_impl(z,
   '''
   shape = z[0].shape
   z, b = vecfield.from_tuple(z), vecfield.from_tuple(b)
+  pml_params = operators.PmlParams(w_eff=params.pml_omega)
 
   pre, inv_pre = operators.preconditioners(
-      shape, params.pml_ths, params.pml_params)
+      shape, params.pml_ths, pml_params)
   def A(x, z): return operators.operator(
-      x, z, pre, inv_pre, params.pml_ths, params.pml_params)
+      x, z, pre, inv_pre, params.pml_ths, pml_params)
 
   # Adjoint solve uses the fact that we already know how to symmetrize the
   # operator, `inv_pre * A * pre == pre * AT * inv_pre`. Note that the resulting

--- a/jaxwell/tests/fdfd_test.py
+++ b/jaxwell/tests/fdfd_test.py
@@ -14,21 +14,17 @@ class TestJaxwell(unittest.TestCase):
     self.b[5, 5, 5] = 1.
     self.b = (0 * self.b, 0 * self.b, self.b)
     self.z = (onp.zeros((10, 10, 10)),) * 3
+    self.params = fdfd.Params(pml_ths=((10, 10), ) * 3,
+                              pml_omega=0.3,
+                              max_iters=1)
 
   def test_solve(self):
-    params = fdfd.Params(pml_ths=((10, 10), ) * 3,
-                         pml_params=operators.PmlParams(w_eff=0.3),
-                         max_iters=1)
-    x, err = fdfd.solve(params, self.z, self.b)
+    x, err = fdfd.solve(self.params, self.z, self.b)
     self.assertAlmostEqual(err, 35.25115523)
 
   def test_grad(self):
-    params = fdfd.Params(pml_ths=((10, 10), ) * 3,
-                         pml_params=operators.PmlParams(w_eff=0.3),
-                         max_iters=1)
-
     def foo(z, b):
-      return vecfield.norm(fdfd.solve(params, z, b))
+      return vecfield.norm(fdfd.solve(self.params, z, b))
 
     grad_z, grad_b = jax.grad(foo, (0, 1))(self.z, self.b)
 
@@ -38,21 +34,14 @@ class TestJaxwell(unittest.TestCase):
                                for g in grad_b), 34.22197829+8.38256152e-15j)
 
   def test_loop_fns(self):
-    params = fdfd.Params(pml_ths=((10, 10), ) * 3,
-                         pml_params=operators.PmlParams(w_eff=0.3),
-                         max_iters=1)
-    x, errs = fdfd.solve_impl(self.z, self.b, params=params)
+    x, errs = fdfd.solve_impl(self.z, self.b, params=self.params)
     self.assertEqual(len(x), 3)
     self.assertEqual(x[0].shape, (10, 10, 10))
     self.assertEqual(len(errs), 1)
     self.assertAlmostEqual(errs[0], 35.25115523)
 
   def test_adjoint(self):
-    params = fdfd.Params(
-        pml_ths=((10, 10), ) * 3,
-        pml_params=operators.PmlParams(w_eff=0.3),
-        max_iters=1)
-    x, errs = fdfd.solve_impl(self.z, self.b, adjoint=True, params=params)
+    x, errs = fdfd.solve_impl(self.z, self.b, adjoint=True, params=self.params)
     self.assertAlmostEqual(errs[0], 0.01358992)
 
 

--- a/jaxwell/tests/fdfd_test.py
+++ b/jaxwell/tests/fdfd_test.py
@@ -1,5 +1,6 @@
 # TODO: Remove.
 import jax
+import jax.numpy as np
 import unittest
 import numpy as onp
 from jaxwell import fdfd, operators, vecfield
@@ -29,7 +30,12 @@ class TestJaxwell(unittest.TestCase):
     def foo(z, b):
       return vecfield.norm(fdfd.solve(params, z, b))
 
-    jax.grad(foo, (0, 1))(self.z, self.b)
+    grad_z, grad_b = jax.grad(foo, (0, 1))(self.z, self.b)
+
+    # Used as pseudo-golden tests.
+    self.assertAlmostEqual(sum(np.sum(g) for g in grad_z), -1484.39503965)
+    self.assertAlmostEqual(sum(np.sum(g)
+                               for g in grad_b), 34.22197829+8.38256152e-15j)
 
   def test_loop_fns(self):
     params = fdfd.Params(pml_ths=((10, 10), ) * 3,


### PR DESCRIPTION
1)  Fix gradient w.r.t. sources -- was missing `conj()`
2) Finesse the `fdfd.Params` interface to simply give `Params.pml_omega` instead of the entire `Params.pml_params` `PmlParams` structure